### PR TITLE
Options support (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![codecov](https://codecov.io/gh/sskorol/webdriver-supplier/branch/master/graph/badge.svg)](https://codecov.io/gh/sskorol/webdriver-supplier)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.sskorol/webdriver-supplier/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/io.github.sskorol/webdriver-supplier)
 [![Bintray](https://api.bintray.com/packages/sskorol/webdriver-supplier/webdriver-supplier/images/download.svg)](https://bintray.com/sskorol/webdriver-supplier/webdriver-supplier/_latestVersion)
-[![Dependency Status](https://www.versioneye.com/user/projects/59b147e16725bd004a5e3a13/badge.svg?style=flat)](https://www.versioneye.com/user/projects/59b147e16725bd004a5e3a13)
 [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://goo.gl/9GLmMZ)
 [![Twitter](https://img.shields.io/twitter/url/https/github.com/sskorol/webdriver-supplier.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20new%20WebDriver%20Supplier%20library:&url=https://github.com/sskorol/webdriver-supplier)
 
@@ -36,8 +35,8 @@ repositories {
 }
     
 dependencies {
-    compile('org.testng:testng:6.11',
-            'io.github.sskorol:webdriver-supplier:0.5.0'
+    compile('org.testng:testng:6.12',
+            'io.github.sskorol:webdriver-supplier:0.6.0'
     )
 }
     
@@ -62,7 +61,7 @@ Add the following configuration into **pom.xml**:
     <dependency>
         <groupId>io.github.sskorol</groupId>
         <artifactId>webdriver-supplier</artifactId>
-        <version>0.5.0</version>
+        <version>0.6.0</version>
     </dependency>
 </dependencies>
     
@@ -157,13 +156,19 @@ public String url() {
 }
 ```
 
-Finally, you can provide your own set of capabilities:
+Finally, you can provide your own set of capabilities or options:
 
 ```java
-public Capabilities configuration(final XmlConfig context) {
-    DesiredCapabilities caps = new DesiredCapabilities();
+public MutableCapabilities configuration(final XmlConfig config) {
+    final DesiredCapabilities caps = new DesiredCapabilities();
     //...
     return caps;
+}
+
+public MutableCapabilities configuration(final XmlConfig config) {
+    final ChromeOptions options = new ChromeOptions();
+    //...
+    return merge(config, options);
 }
 ```
 
@@ -218,10 +223,10 @@ browsers in before class, test group or suite configuration.
 Note that in case of custom capabilities usage, it's recommended to merge them with defaults:
 
 ```java
-public Capabilities configuration(final XmlConfig context) {
-    DesiredCapabilities caps = new DesiredCapabilities();
+public MutableCapabilities configuration(final XmlConfig config) {
+    final DesiredCapabilities caps = new DesiredCapabilities();
     //...
-    return defaultConfiguration(context).merge(caps);
+    return merge(config, caps);
 }
 ```
 
@@ -315,8 +320,8 @@ repositories {
 }
     
 dependencies {
-    compile('org.testng:testng:6.11',
-            'io.github.sskorol:webdriver-supplier:0.5.0'
+    compile('org.testng:testng:6.12',
+            'io.github.sskorol:webdriver-supplier:0.6.0'
     )
 }
     
@@ -341,11 +346,11 @@ public class Firefox implements Browser {
         return true;
     }
     
-    public Capabilities configuration(final XmlConfig context) {
+    public MutableCapabilities configuration(final XmlConfig config) {
         final DesiredCapabilities capabilities = DesiredCapabilities.firefox();
         capabilities.setCapability("enableVNC", true);
         capabilities.setCapability("screenResolution", "1280x1024x24");
-        return defaultConfiguration(context).merge(capabilities);
+        return merge(config, capabilities);
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     id "ru.vyarus.quality" version "2.4.0"
     id "com.jfrog.bintray" version "1.7.3"
-    id 'net.researchgate.release' version '2.4.0'
+    id 'net.researchgate.release' version '2.6.0'
+    id 'com.github.ben-manes.versions' version '0.15.0'
 }
 
 group 'io.github.sskorol'
@@ -27,18 +28,18 @@ repositories {
 }
 
 dependencies {
-    compile('org.testng:testng:6.11',
+    compile('org.testng:testng:6.12',
             'org.jooq:joor:0.9.6',
             'one.util:streamex:0.6.5',
             'org.projectlombok:lombok:1.16.18',
             'io.vavr:vavr:0.9.1',
-            'org.slf4j:slf4j-simple:1.7.25',
+            'org.slf4j:slf4j-simple:1.8.0-beta0',
             'org.seleniumhq.selenium:selenium-java:3.6.0',
             'io.github.bonigarcia:webdrivermanager:1.7.2',
             'org.aeonbits.owner:owner-java8:1.0.9'
     )
     testCompile('org.assertj:assertj-core:3.8.0',
-            'org.mockito:mockito-core:2.10.0',
+            'org.mockito:mockito-core:2.11.0',
             'org.powermock:powermock-api-mockito2:2.0.0-beta.5',
             'org.powermock:powermock-module-testng:2.0.0-beta.5'
     )

--- a/src/main/java/io/github/sskorol/core/Browser.java
+++ b/src/main/java/io/github/sskorol/core/Browser.java
@@ -3,11 +3,14 @@ package io.github.sskorol.core;
 import io.github.sskorol.config.XmlConfig;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
+import static org.openqa.selenium.remote.CapabilityType.PLATFORM;
+import static org.openqa.selenium.remote.CapabilityType.VERSION;
 
 /**
  * Key interface, which should be implemented on client side. Simplifies browser configuration staff.
@@ -36,16 +39,21 @@ public interface Browser {
 
     Name name();
 
-    default Capabilities defaultConfiguration(final XmlConfig context) {
-        final DesiredCapabilities capabilities = new DesiredCapabilities();
-        capabilities.setBrowserName(context.getBrowser());
-        capabilities.setVersion(context.getVersion());
-        capabilities.setPlatform(context.getPlatform());
+    default MutableCapabilities defaultConfiguration(final XmlConfig config) {
+        final MutableCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setCapability(BROWSER_NAME, config.getBrowser());
+        capabilities.setCapability(VERSION, config.getVersion());
+        capabilities.setCapability(PLATFORM, config.getPlatform());
         return capabilities;
     }
 
-    default Capabilities configuration(final XmlConfig context) {
-        return defaultConfiguration(context);
+    default MutableCapabilities configuration(final XmlConfig config) {
+        return defaultConfiguration(config);
+    }
+
+    @SuppressWarnings("unchecked")
+    default <T extends MutableCapabilities> MutableCapabilities merge(final XmlConfig config, final T options) {
+        return options.merge(defaultConfiguration(config));
     }
 
     default boolean isRemote() {

--- a/src/main/java/io/github/sskorol/core/WebDriverFactory.java
+++ b/src/main/java/io/github/sskorol/core/WebDriverFactory.java
@@ -13,8 +13,6 @@ import static io.vavr.API.Match;
 @SuppressWarnings("JavadocType")
 public class WebDriverFactory implements WebDriverProvider {
 
-    public static final String WDP_DEFAULT = "wdp_default";
-
     public String label() {
         return WDP_DEFAULT;
     }

--- a/src/main/java/io/github/sskorol/core/WebDriverProvider.java
+++ b/src/main/java/io/github/sskorol/core/WebDriverProvider.java
@@ -16,6 +16,8 @@ import static org.joor.Reflect.on;
  */
 public interface WebDriverProvider {
 
+    String WDP_DEFAULT = "wdp_default";
+
     String label();
 
     WebDriver createDriver(Browser browser, XmlConfig config);

--- a/src/main/java/io/github/sskorol/listeners/BaseListener.java
+++ b/src/main/java/io/github/sskorol/listeners/BaseListener.java
@@ -40,7 +40,7 @@ public abstract class BaseListener {
                 StreamEx.of(webDriverProviders)
                         .findFirst(this::isWebDriverProviderMatching)
                         .map(wdp -> wdp.createDriver(getCurrentBrowser(context), context))
-                        .map(this::toWebDriverMetaData)
+                        .map(d -> Tuple.of(d, new WebDriverWait(d, WD_CONFIG.wdWaitTimeout())))
                         .orElse(null));
     }
 
@@ -60,19 +60,11 @@ public abstract class BaseListener {
     }
 
     private Browser getCurrentBrowser(final XmlConfig config) {
-        return StreamEx.of(getBrowsers())
+        return StreamEx.of(BROWSERS)
                        .filter(b -> b.name().getBrowserName().equals(config.getBrowser()))
                        .findFirst()
                        .orElseThrow(() -> new SkipException("Unable to find implementation class for "
                                + config.getBrowser() + " browser."));
-    }
-
-    private List<Browser> getBrowsers() {
-        return BROWSERS;
-    }
-
-    private Tuple2<WebDriver, WebDriverWait> toWebDriverMetaData(final WebDriver driver) {
-        return Tuple.of(driver, new WebDriverWait(driver, WD_CONFIG.wdWaitTimeout()));
     }
 
     private boolean isWebDriverProviderMatching(final WebDriverProvider provider) {

--- a/src/main/java/io/github/sskorol/listeners/BeforeMethodListener.java
+++ b/src/main/java/io/github/sskorol/listeners/BeforeMethodListener.java
@@ -29,8 +29,7 @@ public class BeforeMethodListener extends BaseListener implements IInvokedMethod
                     method.getTestMethod().getMethodName())
                     .filter(Optional::isPresent)
                     .map(Optional::get)
-                    .filter(XmlConfig::hasBrowser)
-                    .findFirst()
+                    .findFirst(XmlConfig::hasBrowser)
                     .orElseThrow(() -> new SkipException("Unable to find a valid browser configuration."
                             + " Check if SPI implementation class is provided,"
                             + " and browserName parameter is specified in xml.")));

--- a/src/test/java/io/github/sskorol/config/Edge.java
+++ b/src/test/java/io/github/sskorol/config/Edge.java
@@ -1,10 +1,18 @@
 package io.github.sskorol.config;
 
 import io.github.sskorol.core.Browser;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.edge.EdgeOptions;
 
 public class Edge implements Browser {
 
     public Name name() {
         return Name.Edge;
+    }
+
+
+    @Override
+    public MutableCapabilities configuration(final XmlConfig context) {
+        return merge(context, new EdgeOptions());
     }
 }

--- a/src/test/java/io/github/sskorol/config/Firefox.java
+++ b/src/test/java/io/github/sskorol/config/Firefox.java
@@ -2,6 +2,8 @@ package io.github.sskorol.config;
 
 import io.github.sskorol.core.Browser;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class Firefox implements Browser {
@@ -16,10 +18,10 @@ public class Firefox implements Browser {
     }
 
     @Override
-    public Capabilities configuration(XmlConfig context) {
+    public MutableCapabilities configuration(final XmlConfig config) {
         DesiredCapabilities capabilities = DesiredCapabilities.firefox();
         capabilities.setCapability("enableVNC", true);
         capabilities.setCapability("screenResolution", "1280x1024x24");
-        return defaultConfiguration(context).merge(capabilities);
+        return merge(config, capabilities);
     }
 }


### PR DESCRIPTION
 - Capabilities return type was replaced with MutableCapabilities to make a generic support both for DesiredCapabilities and Options.
 - Updated outdated libs.