### PR TITLE
Capabilities update (fixes #13)

### DIFF
--- a/src/main/java/io/github/sskorol/core/Browser.java
+++ b/src/main/java/io/github/sskorol/core/Browser.java
@@ -3,14 +3,11 @@ package io.github.sskorol.core;
 import io.github.sskorol.config.XmlConfig;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
-import static org.openqa.selenium.remote.CapabilityType.PLATFORM;
-import static org.openqa.selenium.remote.CapabilityType.VERSION;
 
 /**
  * Key interface, which should be implemented on client side. Simplifies browser configuration staff.
@@ -39,20 +36,20 @@ public interface Browser {
 
     Name name();
 
-    default MutableCapabilities defaultConfiguration(final XmlConfig config) {
-        final MutableCapabilities capabilities = new DesiredCapabilities();
-        capabilities.setCapability(BROWSER_NAME, config.getBrowser());
-        capabilities.setCapability(VERSION, config.getVersion());
-        capabilities.setCapability(PLATFORM, config.getPlatform());
+    default Capabilities defaultConfiguration(final XmlConfig config) {
+        final DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setBrowserName(config.getBrowser());
+        capabilities.setVersion(config.getVersion());
+        capabilities.setPlatform(config.getPlatform());
         return capabilities;
     }
 
-    default MutableCapabilities configuration(final XmlConfig config) {
+    default Capabilities configuration(final XmlConfig config) {
         return defaultConfiguration(config);
     }
 
     @SuppressWarnings("unchecked")
-    default <T extends MutableCapabilities> MutableCapabilities merge(final XmlConfig config, final T options) {
+    default <T extends Capabilities> Capabilities merge(final XmlConfig config, final T options) {
         return options.merge(defaultConfiguration(config));
     }
 

--- a/src/test/java/io/github/sskorol/config/Edge.java
+++ b/src/test/java/io/github/sskorol/config/Edge.java
@@ -1,7 +1,7 @@
 package io.github.sskorol.config;
 
 import io.github.sskorol.core.Browser;
-import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.edge.EdgeOptions;
 
 public class Edge implements Browser {
@@ -12,7 +12,7 @@ public class Edge implements Browser {
 
 
     @Override
-    public MutableCapabilities configuration(final XmlConfig context) {
+    public Capabilities configuration(final XmlConfig context) {
         return merge(context, new EdgeOptions());
     }
 }

--- a/src/test/java/io/github/sskorol/config/Firefox.java
+++ b/src/test/java/io/github/sskorol/config/Firefox.java
@@ -2,8 +2,6 @@ package io.github.sskorol.config;
 
 import io.github.sskorol.core.Browser;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class Firefox implements Browser {
@@ -18,7 +16,7 @@ public class Firefox implements Browser {
     }
 
     @Override
-    public MutableCapabilities configuration(final XmlConfig config) {
+    public Capabilities configuration(final XmlConfig config) {
         DesiredCapabilities capabilities = DesiredCapabilities.firefox();
         capabilities.setCapability("enableVNC", true);
         capabilities.setCapability("screenResolution", "1280x1024x24");


### PR DESCRIPTION
Mutable were replaces with generic. Casting issues was related to merging order. Options should be used first, when Desired are used.