### PR TITLE
Test name injection support (fixes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ repositories {
     
 dependencies {
     compile('org.testng:testng:6.12',
-            'io.github.sskorol:webdriver-supplier:0.7.0'
+            'io.github.sskorol:webdriver-supplier:0.7.1'
     )
 }
     
@@ -61,7 +61,7 @@ Add the following configuration into **pom.xml**:
     <dependency>
         <groupId>io.github.sskorol</groupId>
         <artifactId>webdriver-supplier</artifactId>
-        <version>0.7.0</version>
+        <version>0.7.1</version>
     </dependency>
 </dependencies>
     
@@ -173,7 +173,7 @@ public Capabilities configuration(final XmlConfig config) {
 ```
 
 ```XmlConfig``` is a wrapper for TestNG suite. It gives an access to common browser configuration defined as parameters: 
-**browserName**, **version** and **platform**.
+**browserName**, **version** and **platform**. Besides that, you can also retrieve current test name. 
 
 Note that you have to provide at least browser name on any of the following levels:
 
@@ -343,7 +343,7 @@ repositories {
     
 dependencies {
     compile('org.testng:testng:6.12',
-            'io.github.sskorol:webdriver-supplier:0.7.0'
+            'io.github.sskorol:webdriver-supplier:0.7.1'
     )
 }
     
@@ -355,13 +355,13 @@ test {
 }
 ```
 
-##### Chrome.java
+##### Firefox.java
 
 ```java
-public class Chrome implements Browser {
+public class Firefox implements Browser {
     
     public Name name() {
-        return Name.Chrome;
+        return Name.Firefox;
     }
     
     public boolean isRemote() {
@@ -369,8 +369,10 @@ public class Chrome implements Browser {
     }
     
     public Capabilities configuration(final XmlConfig config) {
-        final ChromeOptions options = new ChromeOptions();
+        final FirefoxOptions options = new FirefoxOptions();
         options.setCapability("enableVNC", true);
+        options.setCapability("enableVideo", true);
+        options.setCapability("name", config.getTestName());
         options.setCapability("screenResolution", "1280x1024x24");
         return merge(config, options);
     }
@@ -380,7 +382,7 @@ public class Chrome implements Browser {
 ##### io.github.sskorol.core.Browser
 
 ```text
-full.path.to.Chrome
+full.path.to.Firefox
 ```
 
 ##### smoke-suite.xml
@@ -390,7 +392,7 @@ full.path.to.Chrome
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="Smoke suite">
 	<test name="Chrome group">
-		<parameter name="browserName" value="chrome"/>
+		<parameter name="browserName" value="firefox"/>
 		<parameter name="platform" value="LINUX"/>
 		<classes>
 			<class name="path.to.your.testcases.SmokeTests"/>

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ public class SessionListener implements IInvokedMethodListener {
 
 ## Full example
 
-To establish connection with [Selenoid](http://aerokube.com/selenoid/latest) hub and Chrome node containers 
+To establish connection with [Selenoid](http://aerokube.com/selenoid/latest) hub and Firefox node containers 
 raised on localhost, you can use the following configuration:
 
 ##### build.gradle

--- a/src/main/java/io/github/sskorol/config/XmlConfig.java
+++ b/src/main/java/io/github/sskorol/config/XmlConfig.java
@@ -5,6 +5,7 @@ import org.openqa.selenium.Platform;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.util.Optional.ofNullable;
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
@@ -17,6 +18,7 @@ import static org.openqa.selenium.remote.CapabilityType.VERSION;
 @RequiredArgsConstructor
 public class XmlConfig {
 
+    public static final String TEST_NAME = "testName";
     private final Map<String, String> parameters;
 
     public String getBrowser() {
@@ -33,6 +35,10 @@ public class XmlConfig {
                 .map(String::toUpperCase)
                 .map(Platform::fromString)
                 .orElseGet(Platform::getCurrent);
+    }
+
+    public String getTestName() {
+        return getValue(TEST_NAME).orElse(UUID.randomUUID().toString());
     }
 
     public boolean hasBrowser() {

--- a/src/test/java/io/github/sskorol/config/Firefox.java
+++ b/src/test/java/io/github/sskorol/config/Firefox.java
@@ -19,6 +19,7 @@ public class Firefox implements Browser {
     public Capabilities configuration(final XmlConfig config) {
         DesiredCapabilities capabilities = DesiredCapabilities.firefox();
         capabilities.setCapability("enableVNC", true);
+        capabilities.setCapability("name", config.getTestName());
         capabilities.setCapability("screenResolution", "1280x1024x24");
         return merge(config, capabilities);
     }

--- a/src/test/java/io/github/sskorol/testcases/ConfigTests.java
+++ b/src/test/java/io/github/sskorol/testcases/ConfigTests.java
@@ -10,7 +10,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.github.sskorol.config.WebDriverConfig.WD_CONFIG;
+import static io.github.sskorol.config.XmlConfig.TEST_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
+import static org.openqa.selenium.remote.CapabilityType.PLATFORM;
+import static org.openqa.selenium.remote.CapabilityType.VERSION;
 
 public class ConfigTests {
 
@@ -29,9 +33,9 @@ public class ConfigTests {
     @Test
     public void shouldWrapMainXmlParameters() {
         final Map<String, String> parameters = new HashMap<>();
-        parameters.put("browserName", "chrome");
-        parameters.put("version", "60.0");
-        parameters.put("platform", "WINDOWS");
+        parameters.put(BROWSER_NAME, "chrome");
+        parameters.put(VERSION, "60.0");
+        parameters.put(PLATFORM, "WINDOWS");
 
         final XmlConfig config = new XmlConfig(parameters);
         assertThat(config.hasBrowser()).isTrue();
@@ -42,9 +46,9 @@ public class ConfigTests {
     @Test
     public void shouldProvideBrowserConfiguration() {
         final Map<String, String> parameters = new HashMap<>();
-        parameters.put("browserName", "firefox");
-        parameters.put("version", "55.0");
-        parameters.put("platform", "linux");
+        parameters.put(BROWSER_NAME, "firefox");
+        parameters.put(VERSION, "55.0");
+        parameters.put(PLATFORM, "linux");
 
         final XmlConfig config = new XmlConfig(parameters);
         assertThat(config).extracting(XmlConfig::getBrowser).containsExactly("firefox");
@@ -55,7 +59,7 @@ public class ConfigTests {
     @Test(expectedExceptions = WebDriverException.class)
     public void shouldThrowAnExceptionOnIllegalPlatform() {
         final Map<String, String> parameters = new HashMap<>();
-        parameters.put("platform", "os");
+        parameters.put(PLATFORM, "os");
         new XmlConfig(parameters).getPlatform();
     }
 
@@ -84,5 +88,22 @@ public class ConfigTests {
 
         assertThat(config.hasValue("key")).isTrue();
         assertThat(config).extracting(c -> c.getValue("key")).containsExactly(Optional.of("value"));
+    }
+
+    @Test
+    public void shouldProvideValidTestName() {
+        final String testName = "shouldProvideValidTestName";
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put(TEST_NAME, testName);
+        final XmlConfig config = new XmlConfig(parameters);
+
+        assertThat(config)
+                .extracting(XmlConfig::getTestName)
+                .containsExactly(testName);
+    }
+
+    @Test
+    public void shouldProvideRandomTestNameOnMissingParameter() {
+        assertThat(new XmlConfig(new HashMap<>()).getTestName()).isNotBlank();
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/CoreTests.java
+++ b/src/test/java/io/github/sskorol/testcases/CoreTests.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.github.sskorol.config.XmlConfig.TEST_NAME;
 import static io.github.sskorol.core.WebDriverFactory.WDP_DEFAULT;
 import static io.github.sskorol.utils.ServiceLoaderUtils.load;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,6 +160,7 @@ public class CoreTests extends PowerMockTestCase {
             {
                 put(BROWSER_NAME, "firefox");
                 put(PLATFORM, "ANY");
+                put(TEST_NAME, "shouldCreateRemoteDriverInstance");
             }
         });
 


### PR DESCRIPTION
 - injected current test name into xml config entity, so that it could be easily retrieved while capabilities processing;