### PR TITLE
GITHUB-30: improve logging on bad configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ repositories {
     
 dependencies {
     compile(
-            'org.testng:testng:7.4.0',
-            'io.github.sskorol:webdriver-supplier:0.9.2'
+            'org.testng:testng:7.5',
+            'io.github.sskorol:webdriver-supplier:0.9.3'
     )
 }
     
@@ -56,12 +56,12 @@ Add the following configuration into **pom.xml**:
     <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
-        <version>7.4.0</version>
+        <version>7.5</version>
     </dependency>
     <dependency>
         <groupId>io.github.sskorol</groupId>
         <artifactId>webdriver-supplier</artifactId>
-        <version>0.9.2</version>
+        <version>0.9.3</version>
     </dependency>
 </dependencies>
     

--- a/build.gradle
+++ b/build.gradle
@@ -39,16 +39,16 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     testAnnotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     implementation(
-            'org.testng:testng:7.4.0',
+            'org.testng:testng:7.5',
             'org.jooq:joor:0.9.14',
-            'one.util:streamex:0.8.0',
+            'one.util:streamex:0.8.1',
             'io.vavr:vavr:0.10.4',
-            'org.seleniumhq.selenium:selenium-java:4.1.1',
-            'io.github.bonigarcia:webdrivermanager:5.0.3',
+            'org.seleniumhq.selenium:selenium-java:4.1.3',
+            'io.github.bonigarcia:webdrivermanager:5.1.1',
             'org.aeonbits.owner:owner:1.0.12',
             'org.apache.commons:commons-lang3:3.12.0'
     )
-    testImplementation('org.assertj:assertj-core:3.21.0',
+    testImplementation('org.assertj:assertj-core:3.22.0',
             'org.mockito:mockito-core:2.12.0',
             'org.powermock:powermock-api-mockito2:2.0.9',
             'org.powermock:powermock-module-testng:2.0.9'
@@ -69,7 +69,7 @@ jacocoTestReport {
 }
 
 tasks.named('wrapper') {
-    gradleVersion = '7.2'
+    gradleVersion = '7.4.2'
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-SNAPSHOT
+version=0.9.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/sskorol/config/XmlConfig.java
+++ b/src/main/java/io/github/sskorol/config/XmlConfig.java
@@ -1,6 +1,7 @@
 package io.github.sskorol.config;
 
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.openqa.selenium.Platform;
 
 import java.util.Map;
@@ -14,6 +15,7 @@ import static org.openqa.selenium.remote.CapabilityType.*;
  * TestNG xml wrapper, which stores parsed browser configuration.
  */
 @RequiredArgsConstructor
+@SuppressWarnings("FinalLocalVariable")
 public class XmlConfig {
 
     public static final String TEST_NAME = "testName";
@@ -21,7 +23,8 @@ public class XmlConfig {
 
     public String getBrowser() {
         return getValue(BROWSER_NAME)
-                .orElseThrow(() -> new IllegalArgumentException("browserName parameter is required"));
+            .filter(browser -> !browser.isEmpty())
+            .orElseThrow(() -> new IllegalArgumentException("browserName parameter is required"));
     }
 
     public String getVersion() {
@@ -30,9 +33,9 @@ public class XmlConfig {
 
     public Platform getPlatform() {
         return getValue(PLATFORM_NAME)
-                .map(String::toUpperCase)
-                .map(Platform::fromString)
-                .orElseGet(Platform::getCurrent);
+            .map(String::toUpperCase)
+            .map(Platform::fromString)
+            .orElseGet(Platform::getCurrent);
     }
 
     public String getTestName() {
@@ -57,5 +60,24 @@ public class XmlConfig {
 
     public Optional<String> getValue(final String key) {
         return ofNullable(parameters.get(key));
+    }
+
+    @Override
+    public String toString() {
+        val browser = getBrowser();
+        val version = getVersion();
+        val platform = getPlatform();
+        val message = new StringBuilder(browser);
+        val separator = " ";
+
+        if (!version.isEmpty()) {
+            message.append(separator).append(version);
+        }
+
+        if (!platform.toString().isEmpty()) {
+            message.append(separator).append(platform);
+        }
+
+        return message.toString().trim();
     }
 }

--- a/src/main/java/io/github/sskorol/core/WebDriverProvider.java
+++ b/src/main/java/io/github/sskorol/core/WebDriverProvider.java
@@ -36,7 +36,8 @@ public interface WebDriverProvider {
         return driver.create(new URL(browser.url()), browser.configuration(config));
     }
 
+    @SuppressWarnings("unchecked")
     default void setupDriver(final Reflect driver) {
-        WebDriverManager.getInstance(driver.type()).setup();
+        WebDriverManager.getInstance((Class<? extends WebDriver>) driver.type()).setup();
     }
 }

--- a/src/main/java/io/github/sskorol/listeners/BeforeMethodListener.java
+++ b/src/main/java/io/github/sskorol/listeners/BeforeMethodListener.java
@@ -1,6 +1,7 @@
 package io.github.sskorol.listeners;
 
 import io.github.sskorol.config.XmlConfig;
+import lombok.val;
 import org.testng.*;
 
 import java.util.*;
@@ -10,6 +11,7 @@ import static io.github.sskorol.utils.TestNGUtils.getBrowserConfiguration;
 /**
  * Key listener which should be included on client side. Creates / cleans WebDrivers before/after test invocation.
  */
+@SuppressWarnings("FinalLocalVariable")
 public class BeforeMethodListener extends BaseListener implements IInvokedMethodListener, ISuiteListener {
 
     @Override
@@ -25,14 +27,17 @@ public class BeforeMethodListener extends BaseListener implements IInvokedMethod
     @Override
     public void beforeInvocation(final IInvokedMethod method, final ITestResult testResult) {
         if (method.isTestMethod()) {
-            setupDriver(getBrowserConfiguration(testResult.getTestContext().getCurrentXmlTest(),
-                    method.getTestMethod().getMethodName())
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .findFirst(XmlConfig::hasBrowser)
-                    .orElseThrow(() -> new SkipException("Unable to find a valid browser configuration."
-                            + " Check if SPI implementation class is provided,"
-                            + " and browserName parameter is specified in xml.")), testResult);
+            val config = getBrowserConfiguration(
+                testResult.getTestContext().getCurrentXmlTest(),
+                method.getTestMethod().getMethodName()
+            )
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst(XmlConfig::hasBrowser)
+                .orElseThrow(() -> new SkipException("Unable to find a valid browser configuration. Check if SPI "
+                                                     + "implementation class is provided, "
+                                                     + "and browserName parameter is specified in xml."));
+            setupDriver(config, testResult);
         }
     }
 

--- a/src/test/java/io/github/sskorol/config/PowerMockObjectFactory.java
+++ b/src/test/java/io/github/sskorol/config/PowerMockObjectFactory.java
@@ -1,0 +1,48 @@
+package io.github.sskorol.config;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.testng.internal.PowerMockClassloaderObjectFactory;
+import org.testng.ITestObjectFactory;
+import org.testng.internal.objects.ObjectFactoryImpl;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+public class PowerMockObjectFactory implements ITestObjectFactory {
+
+    private final PowerMockClassloaderObjectFactory powerMockObjectFactory = new PowerMockClassloaderObjectFactory();
+    private final ObjectFactoryImpl defaultObjectFactory = new ObjectFactoryImpl();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T newInstance(Constructor<T> constructor, Object... params) {
+        final T testInstance;
+        Class<?> testClass = constructor.getDeclaringClass();
+        if (hasPowerMockAnnotation(testClass)) {
+            testInstance = (T) powerMockObjectFactory.newInstance(constructor, params);
+        } else {
+            testInstance = defaultObjectFactory.newInstance(constructor, params);
+        }
+
+        return testInstance;
+    }
+
+    private boolean hasPowerMockAnnotation(Class<?> testClass) {
+        return isClassAnnotatedWithPowerMockAnnotation(testClass) || anyMethodInClassHasPowerMockAnnotation(testClass);
+    }
+
+    private boolean anyMethodInClassHasPowerMockAnnotation(Class<?> testClass) {
+        final Method[] methods = testClass.getMethods();
+        for (Method method : methods) {
+            if (method.isAnnotationPresent(PrepareForTest.class) || method.isAnnotationPresent(SuppressStaticInitializationFor.class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isClassAnnotatedWithPowerMockAnnotation(Class<?> testClass) {
+        return testClass.isAnnotationPresent(PrepareForTest.class) || testClass.isAnnotationPresent(SuppressStaticInitializationFor.class);
+    }
+}

--- a/src/test/java/io/github/sskorol/testcases/ConfigTests.java
+++ b/src/test/java/io/github/sskorol/testcases/ConfigTests.java
@@ -1,6 +1,7 @@
 package io.github.sskorol.testcases;
 
 import io.github.sskorol.config.XmlConfig;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriverException;
 import org.testng.annotations.Test;
@@ -11,6 +12,7 @@ import java.util.Optional;
 
 import static io.github.sskorol.config.WebDriverConfig.WD_CONFIG;
 import static io.github.sskorol.config.XmlConfig.TEST_NAME;
+import static io.github.sskorol.utils.StringUtils.toDimension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openqa.selenium.remote.CapabilityType.*;
 
@@ -41,6 +43,16 @@ public class ConfigTests {
     }
 
     @Test
+    public void shouldConvertToDimension() {
+        assertThat(toDimension("1280x1024x24")).isEqualTo(Optional.of(new Dimension(1280, 1024)));
+    }
+
+    @Test
+    public void shouldFailConvertingToDimension() {
+        assertThat(toDimension("1280")).isEqualTo(Optional.empty());
+    }
+
+    @Test
     public void shouldWrapMainXmlParameters() {
         final Map<String, String> parameters = new HashMap<>();
         parameters.put(BROWSER_NAME, "chrome");
@@ -64,6 +76,46 @@ public class ConfigTests {
         assertThat(config).extracting(XmlConfig::getBrowser).isEqualTo("firefox");
         assertThat(config).extracting(XmlConfig::getVersion).isEqualTo("55.0");
         assertThat(config).extracting(XmlConfig::getPlatform).isEqualTo(Platform.LINUX);
+    }
+
+    @Test
+    public void shouldPrintFullBrowserConfiguration() {
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put(BROWSER_NAME, "chrome");
+        parameters.put(BROWSER_VERSION, "96.0");
+        parameters.put(PLATFORM_NAME, "linux");
+
+        final XmlConfig config = new XmlConfig(parameters);
+        assertThat(config.toString()).isEqualTo("chrome 96.0 LINUX");
+    }
+
+    @Test
+    public void shouldPrintBrowserConfigurationWithoutVersion() {
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put(BROWSER_NAME, "chrome");
+        parameters.put(PLATFORM_NAME, "mac");
+
+        final XmlConfig config = new XmlConfig(parameters);
+        assertThat(config.toString()).isEqualTo("chrome MAC");
+    }
+
+    @Test
+    public void shouldPrintBrowserConfigurationWithoutPlatform() {
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put(BROWSER_NAME, "chrome");
+        parameters.put(BROWSER_VERSION, "99.9");
+
+        final XmlConfig config = new XmlConfig(parameters);
+        assertThat(config.toString()).isEqualTo("chrome 99.9 MAC");
+    }
+
+    @Test
+    public void shouldPrintBrowserConfigurationWithoutVersionAndPlatform() {
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put(BROWSER_NAME, "chrome");
+
+        final XmlConfig config = new XmlConfig(parameters);
+        assertThat(config.toString()).isEqualTo("chrome MAC");
     }
 
     @Test(expectedExceptions = WebDriverException.class)

--- a/src/test/java/io/github/sskorol/testcases/CoreTests.java
+++ b/src/test/java/io/github/sskorol/testcases/CoreTests.java
@@ -1,6 +1,7 @@
 package io.github.sskorol.testcases;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
+import io.github.sskorol.config.PowerMockObjectFactory;
 import io.github.sskorol.config.XmlConfig;
 import io.github.sskorol.core.Browser;
 import io.github.sskorol.core.WebDriverProvider;
@@ -15,7 +16,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.IObjectFactory;
+import org.testng.ITestObjectFactory;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.ObjectFactory;
@@ -50,11 +51,11 @@ public class CoreTests extends PowerMockTestCase {
         browsers = load(Browser.class, getClass().getClassLoader());
         factories = load(WebDriverProvider.class, getClass().getClassLoader());
         defaultFactory = StreamEx.of(factories)
-                                 .findFirst(f -> f.label().equals(WDP_DEFAULT))
-                                 .orElseThrow(() -> new AssertionError("Unable to get default factory"));
+            .findFirst(f -> f.label().equals(WDP_DEFAULT))
+            .orElseThrow(() -> new AssertionError("Unable to get default factory"));
         firefox = StreamEx.of(browsers)
-                          .findFirst(f -> f.name() == Browser.Name.Firefox)
-                          .orElseThrow(() -> new AssertionError("Unable to get Firefox implementation"));
+            .findFirst(f -> f.name() == Browser.Name.Firefox)
+            .orElseThrow(() -> new AssertionError("Unable to get Firefox implementation"));
     }
 
     @Test
@@ -65,39 +66,45 @@ public class CoreTests extends PowerMockTestCase {
     @Test
     public void browsersShouldHaveProvidedEnumConstants() {
         assertThat(browsers)
-                .extracting(Browser::name)
-                .containsExactlyInAnyOrder(Browser.Name.Chrome,
-                        Browser.Name.Edge,
-                        Browser.Name.Firefox,
-                        Browser.Name.InternetExplorer);
+            .extracting(Browser::name)
+            .containsExactlyInAnyOrder(
+                Browser.Name.Chrome,
+                Browser.Name.Edge,
+                Browser.Name.Firefox,
+                Browser.Name.InternetExplorer
+            );
     }
 
     @Test
     public void browsersShouldHaveDefaultNames() {
         assertThat(browsers)
-                .extracting(Browser::name)
-                .extracting(Browser.Name::getBrowserName)
-                .containsExactlyInAnyOrder("chrome", "firefox", "edge", "ie");
+            .extracting(Browser::name)
+            .extracting(Browser.Name::getBrowserName)
+            .containsExactlyInAnyOrder("chrome", "firefox", "edge", "ie");
     }
 
     @Test
     public void browsersShouldHaveDefaultDrivers() {
         assertThat(browsers)
-                .extracting(Browser::name)
-                .extracting(Browser.Name::getDriverClassName)
-                .containsExactlyInAnyOrder("org.openqa.selenium.chrome.ChromeDriver",
-                        "org.openqa.selenium.firefox.FirefoxDriver",
-                        "org.openqa.selenium.edge.EdgeDriver",
-                        "org.openqa.selenium.ie.InternetExplorerDriver");
+            .extracting(Browser::name)
+            .extracting(Browser.Name::getDriverClassName)
+            .containsExactlyInAnyOrder(
+                "org.openqa.selenium.chrome.ChromeDriver",
+                "org.openqa.selenium.firefox.FirefoxDriver",
+                "org.openqa.selenium.edge.EdgeDriver",
+                "org.openqa.selenium.ie.InternetExplorerDriver"
+            );
     }
 
     @Test
     public void shouldRetrievePrecededBrowsers() {
-        assertThat(Browser.Name.values()).containsExactly(Browser.Name.Chrome,
-                Browser.Name.Firefox,
-                Browser.Name.InternetExplorer,
-                Browser.Name.Edge,
-                Browser.Name.Remote);
+        assertThat(Browser.Name.values()).containsExactly(
+            Browser.Name.Chrome,
+            Browser.Name.Firefox,
+            Browser.Name.InternetExplorer,
+            Browser.Name.Edge,
+            Browser.Name.Remote
+        );
     }
 
     @Test
@@ -117,20 +124,20 @@ public class CoreTests extends PowerMockTestCase {
 
         final XmlConfig config = new XmlConfig(chromeParameters);
         final Browser chrome = StreamEx.of(browsers)
-                                       .findFirst(b -> b.name() == Browser.Name.Chrome)
-                                       .orElseThrow(() -> new AssertionError("Unable to retrieve Chrome"));
+            .findFirst(b -> b.name() == Browser.Name.Chrome)
+            .orElseThrow(() -> new AssertionError("Unable to retrieve Chrome"));
 
         assertThat(chrome.isRemote()).isFalse();
         assertThat(chrome.url()).isEqualTo("http://localhost:4444/wd/hub");
         assertThat(chrome.defaultConfiguration(config))
-                .extracting(Capabilities::getBrowserName)
-                .isEqualTo("chrome");
+            .extracting(Capabilities::getBrowserName)
+            .isEqualTo("chrome");
         assertThat(chrome.defaultConfiguration(config))
-                .extracting(Capabilities::getBrowserVersion)
-                .isEqualTo("");
+            .extracting(Capabilities::getBrowserVersion)
+            .isEqualTo("");
         assertThat(chrome.defaultConfiguration(config))
-                .extracting(Capabilities::getPlatformName)
-                .isEqualTo(Platform.getCurrent());
+            .extracting(Capabilities::getPlatformName)
+            .isEqualTo(Platform.getCurrent());
         assertThat(chrome.configuration(config)).isEqualTo(chrome.defaultConfiguration(config));
     }
 
@@ -141,8 +148,8 @@ public class CoreTests extends PowerMockTestCase {
 
         final XmlConfig config = new XmlConfig(edgeParameters);
         final Browser edge = StreamEx.of(browsers)
-                                       .findFirst(b -> b.name() == Browser.Name.Edge)
-                                       .orElseThrow(() -> new AssertionError("Unable to retrieve Edge"));
+            .findFirst(b -> b.name() == Browser.Name.Edge)
+            .orElseThrow(() -> new AssertionError("Unable to retrieve Edge"));
 
         assertThat(edge.configuration(config)).isEqualTo(edge.merge(config, new EdgeOptions()));
     }
@@ -174,11 +181,12 @@ public class CoreTests extends PowerMockTestCase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldCreateLocalDriverInstance() {
         Browser edge = StreamEx.of(browsers)
-                                 .findFirst(f -> f.name() == Browser.Name.Edge)
-                                 .orElseThrow(() -> new AssertionError(
-                                         "Unable to get Edge implementation"));
+            .findFirst(f -> f.name() == Browser.Name.Edge)
+            .orElseThrow(() -> new AssertionError(
+                "Unable to get Edge implementation"));
 
         XmlConfig config = new XmlConfig(new HashMap<>() {
             {
@@ -192,7 +200,8 @@ public class CoreTests extends PowerMockTestCase {
         WebDriverProvider spyFactory = spy(defaultFactory);
         Reflect spyReflectedDriver = spy(spyFactory.wrapDriver(edge));
 
-        PowerMockito.when(WebDriverManager.getInstance(spyReflectedDriver.type())).thenReturn(browserManager);
+        PowerMockito.when(WebDriverManager.getInstance((Class<? extends WebDriver>) spyReflectedDriver.type()))
+            .thenReturn(browserManager);
         doNothing().when(browserManager).setup();
         doReturn(spyReflectedDriver).when(spyFactory).wrapDriver(edge);
         doReturn(on(driver)).when(spyReflectedDriver).create(edge.configuration(config));
@@ -213,12 +222,12 @@ public class CoreTests extends PowerMockTestCase {
         doReturn("localhost").when(browser).url();
 
         assertThat(catchThrowable(() -> defaultFactory.createDriver(browser, config)))
-                .isInstanceOf(SkipException.class)
-                .hasStackTraceContaining("java.net.MalformedURLException");
+            .isInstanceOf(SkipException.class)
+            .hasStackTraceContaining("java.net.MalformedURLException");
     }
 
     @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    public ITestObjectFactory getObjectFactory() {
+        return new PowerMockObjectFactory();
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/ListenerTests.java
+++ b/src/test/java/io/github/sskorol/testcases/ListenerTests.java
@@ -24,7 +24,7 @@ public class ListenerTests {
     public void shouldCallDefaultListenerWithMockProvider() {
         final InvokedMethodNameListener nameListener = run("src/test/resources/testng1.xml",
                 this::getDefaultListener);
-        assertThat(nameListener.getSkippedMethodNames()).hasSize(2);
+        assertThat(nameListener.getSkippedMethods()).hasSize(2);
         assertThat(nameListener.getSucceedMethodNames()).hasSize(1);
     }
 
@@ -46,14 +46,14 @@ public class ListenerTests {
     public void shouldCallCustomListenerForCustomProvider() {
         final InvokedMethodNameListener nameListener = run("src/test/resources/testng3.xml",
                 () -> getCustomListener(p -> !WDP_DEFAULT.equals(p.label()), 1));
-        assertThat(nameListener.getFailedMethodNames()).hasSize(8);
+        assertThat(nameListener.getSkippedMethods()).hasSize(8);
     }
 
     @Test
     public void shouldCallCustomListenerForDuplicateDefaultProviders() {
         final InvokedMethodNameListener nameListener = run("src/test/resources/testng3.xml",
                 () -> getCustomListener(p -> WDP_DEFAULT.equals(p.label()), 2));
-        assertThat(nameListener.getFailedMethodNames()).hasSize(8);
+        assertThat(nameListener.getSkippedMethods()).hasSize(8);
     }
 
     @Test

--- a/src/test/java/io/github/sskorol/testcases/ReflectionTests.java
+++ b/src/test/java/io/github/sskorol/testcases/ReflectionTests.java
@@ -1,6 +1,7 @@
 package io.github.sskorol.testcases;
 
 import io.github.sskorol.utils.ServiceLoaderUtils;
+import io.github.sskorol.utils.StringUtils;
 import io.github.sskorol.utils.TestNGUtils;
 import org.testng.annotations.Test;
 
@@ -19,6 +20,12 @@ public class ReflectionTests {
     public void shouldThrowAnExceptionOnServiceLoaderUtilsConstructorAccess() {
         assertThatThrownBy(() -> onClass(ServiceLoaderUtils.class).create())
                 .hasStackTraceContaining("java.lang.UnsupportedOperationException: Illegal access to private constructor");
+    }
+
+    @Test
+    public void shouldThrowAnExceptionOnStringUtilsConstructorAccess() {
+        assertThatThrownBy(() -> onClass(StringUtils.class).create())
+            .hasStackTraceContaining("java.lang.UnsupportedOperationException: Illegal access to private constructor");
     }
 
     @Test


### PR DESCRIPTION
There was a bug in TestNG 7.4.0 that prevented tests from skipping in case of configuration issue in listeners. This update includes a dependencies' fix + minor improvements on exceptions' logic in before method listener. Apart from that there code coverage was extended.

Fixes #30