### PR TITLE
GITHUB-32 / GITHUB-33: migrate to Java 17 and add CDP support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,12 @@
 plugins {
     id "java-library"
     id "java"
-    id 'ru.vyarus.quality' version '4.3.0'
+    id 'ru.vyarus.quality' version '4.7.0'
     id "jacoco"
     id "maven-publish"
     id "signing"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
-    id "net.researchgate.release" version "2.8.1"
-    id "com.ferranpons.twitterplugin" version "1.1.0"
-    id "com.github.ben-manes.versions" version "0.39.0"
+    id "com.github.ben-manes.versions" version "0.42.0"
 }
 
 group 'io.github.sskorol'
@@ -19,14 +17,14 @@ ext {
     gradleScriptDir = "${rootProject.projectDir}/gradle".toString()
     projectUrl = "https://github.com/sskorol/webdriver-supplier"
     moduleName = "io.github.sskorol.webdriversupplier"
-    lombokVersion = "1.18.22"
+    lombokVersion = "1.18.24"
 }
 
 apply plugin: 'java'
 apply plugin: 'jacoco'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -35,18 +33,23 @@ repositories {
 
 dependencies {
     compileOnly("org.projectlombok:lombok:${lombokVersion}")
+    compileOnly('com.google.code.findbugs:findbugs-annotations:3.0.1')
     testCompileOnly("org.projectlombok:lombok:${lombokVersion}")
     annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     testAnnotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     implementation(
-            'org.testng:testng:7.5',
+            'org.testng:testng:7.6.0',
             'org.jooq:joor:0.9.14',
             'one.util:streamex:0.8.1',
             'io.vavr:vavr:0.10.4',
-            'org.seleniumhq.selenium:selenium-java:4.1.3',
+            'org.seleniumhq.selenium:selenium-java:4.1.4',
+            'org.bouncycastle:bcprov-jdk15on:1.70',
+            'com.fasterxml.jackson.core:jackson-databind:2.13.3',
             'io.github.bonigarcia:webdrivermanager:5.1.1',
             'org.aeonbits.owner:owner:1.0.12',
-            'org.apache.commons:commons-lang3:3.12.0'
+            'commons-io:commons-io:2.11.0',
+            'org.apache.commons:commons-lang3:3.12.0',
+            'io.github.sskorol:cdt-java-client:5.0.0'
     )
     testImplementation('org.assertj:assertj-core:3.22.0',
             'org.mockito:mockito-core:2.12.0',
@@ -59,7 +62,7 @@ if (project.hasProperty('release')) {
     apply from: "${gradleScriptDir}/maven-publish.gradle"
 }
 
-jacoco.toolVersion = "0.8.7"
+jacoco.toolVersion = "0.8.8"
 jacocoTestReport {
     reports {
         xml.required = true
@@ -75,5 +78,9 @@ tasks.named('wrapper') {
 test {
     useTestNG() {
         suites 'src/test/resources/smoke-suite.xml'
+    }
+
+    doFirst {
+        jvmArgs = ['--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED']
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.3
+version=0.9.4

--- a/gradle/maven-publish.gradle
+++ b/gradle/maven-publish.gradle
@@ -1,7 +1,5 @@
-apply plugin: 'net.researchgate.release'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'com.ferranpons.twitterplugin'
 
 File secretPropsFile = project.rootProject.file('local.properties')
 if (secretPropsFile.exists()) {
@@ -128,18 +126,4 @@ signing {
 
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
-}
-
-twitterPlugin {
-    def shouldTweet = project.hasProperty('shouldTweet') ? project.property('shouldTweet') : System.getenv('SHOULD_TWEET')
-    if (shouldTweet && shouldTweet.toBoolean()) {
-        def releaseVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : System.getenv('RELEASE_VERSION')
-        def tweet = "Test Data Supplier ${releaseVersion} has been released: ${project.projectUrl} #testng #testdatasupplier #java"
-
-        consumerKey = project.ext["twitter.consumerKey"]
-        consumerSecret = project.ext["twitter.consumerSecret"]
-        accessToken = project.ext["twitter.accessToken"]
-        accessTokenSecret = project.ext["twitter.accessTokenSecret"]
-        message = "${tweet}"
-    }
 }

--- a/src/main/java/io/github/sskorol/config/XmlConfig.java
+++ b/src/main/java/io/github/sskorol/config/XmlConfig.java
@@ -1,5 +1,6 @@
 package io.github.sskorol.config;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.openqa.selenium.Platform;
@@ -16,6 +17,7 @@ import static org.openqa.selenium.remote.CapabilityType.*;
  */
 @RequiredArgsConstructor
 @SuppressWarnings("FinalLocalVariable")
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class XmlConfig {
 
     public static final String TEST_NAME = "testName";

--- a/src/main/java/io/github/sskorol/core/CDP.java
+++ b/src/main/java/io/github/sskorol/core/CDP.java
@@ -1,0 +1,22 @@
+package io.github.sskorol.core;
+
+import io.github.sskorol.cdt.services.ChromeDevToolsService;
+import io.github.sskorol.cdt.services.exceptions.WebSocketServiceException;
+
+import java.net.URISyntaxException;
+
+/**
+ * An interface for working Chrome DevTools Protocol.
+ */
+public interface CDP {
+
+    default ChromeDevToolsService initCDP(final String sessionId) {
+        try {
+            return ChromeDevToolsService.from(cdpWebSocketUrl(sessionId));
+        } catch (WebSocketServiceException | URISyntaxException ignored) {
+            return null;
+        }
+    }
+
+    String cdpWebSocketUrl(String sessionId);
+}

--- a/src/main/java/io/github/sskorol/core/WebDriverContainer.java
+++ b/src/main/java/io/github/sskorol/core/WebDriverContainer.java
@@ -1,0 +1,24 @@
+package io.github.sskorol.core;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.sskorol.cdt.services.ChromeDevToolsService;
+import lombok.Data;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Encapsulates driver, wait and devtools services.
+ */
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
+@Data
+public class WebDriverContainer {
+
+    private final WebDriver webDriver;
+    private final WebDriverWait webDriverWait;
+    private ChromeDevToolsService devToolsService;
+
+    public WebDriverContainer withDevToolsService(final ChromeDevToolsService devToolsService) {
+        this.devToolsService = devToolsService;
+        return this;
+    }
+}

--- a/src/main/java/io/github/sskorol/listeners/BaseListener.java
+++ b/src/main/java/io/github/sskorol/listeners/BaseListener.java
@@ -1,11 +1,8 @@
 package io.github.sskorol.listeners;
 
-import io.github.sskorol.core.Browser;
-import io.github.sskorol.core.ScreenshotConsumer;
-import io.github.sskorol.core.WebDriverProvider;
+import io.github.sskorol.cdt.services.ChromeDevToolsService;
+import io.github.sskorol.core.*;
 import io.github.sskorol.config.XmlConfig;
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
 import io.vavr.control.Try;
 import lombok.val;
 import one.util.streamex.StreamEx;
@@ -16,25 +13,25 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static io.github.sskorol.utils.ServiceLoaderUtils.load;
 import static io.github.sskorol.config.WebDriverConfig.WD_CONFIG;
 import static io.github.sskorol.core.WebDriverFactory.WDP_DEFAULT;
+import static java.time.Duration.ofSeconds;
 import static java.util.Optional.ofNullable;
 import static org.openqa.selenium.OutputType.BYTES;
 
 @SuppressWarnings({"MissingJavadocType", "FinalLocalVariable"})
 public abstract class BaseListener {
 
-    private static final ThreadLocal<Tuple2<WebDriver, WebDriverWait>> DRIVER_CONTAINER = new ThreadLocal<>();
+    private static final ThreadLocal<WebDriverContainer> DRIVER_CONTAINER = new ThreadLocal<>();
     private static final List<Browser> BROWSERS = new CopyOnWriteArrayList<>();
     private static final List<WebDriverProvider> WEB_DRIVER_PROVIDERS = new CopyOnWriteArrayList<>();
     private static final List<ScreenshotConsumer> SCREENSHOT_CONSUMERS = new CopyOnWriteArrayList<>();
 
-    public static Tuple2<WebDriver, WebDriverWait> getDriverMetaData() {
+    public static WebDriverContainer getDriverMetaData() {
         return DRIVER_CONTAINER.get();
     }
 
@@ -43,11 +40,13 @@ public abstract class BaseListener {
     }
 
     public void setupDriver(final XmlConfig context, final ITestResult testResult) {
-        final List<WebDriverProvider> webDriverProviders = getWebDriverProviders();
+        val webDriverProviders = getWebDriverProviders();
+        val browser = getCurrentBrowser(context);
         val driver = StreamEx.of(webDriverProviders)
             .findFirst(this::isWebDriverProviderMatching)
-            .map(wdp -> wdp.createDriver(getCurrentBrowser(context), context))
-            .map(d -> Tuple.of(d, new WebDriverWait(d, Duration.ofSeconds(WD_CONFIG.wdWaitTimeout()))))
+            .map(wdp -> wdp.createDriver(browser, context))
+            .map(d -> new WebDriverContainer(d, new WebDriverWait(d, ofSeconds(WD_CONFIG.wdWaitTimeout())))
+                .withDevToolsService(getDevToolsService(browser, d)))
             .orElse(null);
 
         if (driver == null) {
@@ -61,8 +60,10 @@ public abstract class BaseListener {
     public void cleanUp(final ITestResult testResult) {
         ofNullable(getDriverMetaData())
             .ifPresent(md -> {
-                takeScreenshot(md._1, testResult);
-                Try.run(md._1::quit);
+                ofNullable(md.getDevToolsService()).ifPresent(cdp -> Try.run(cdp::close));
+                val driver = md.getWebDriver();
+                takeScreenshot(driver, testResult);
+                Try.run(driver::quit);
             });
         DRIVER_CONTAINER.remove();
     }
@@ -87,6 +88,11 @@ public abstract class BaseListener {
                                                  + config.getBrowser() + " browser."));
     }
 
+    private ChromeDevToolsService getDevToolsService(final Browser browser, final WebDriver driver) {
+        return CDP.class.isAssignableFrom(browser.getClass()) && driver instanceof RemoteWebDriver
+               ? ((CDP) browser).initCDP(((RemoteWebDriver) driver).getSessionId().toString()) : null;
+    }
+
     private boolean isWebDriverProviderMatching(final WebDriverProvider provider) {
         final List<WebDriverProvider> webDriverProviders = getWebDriverProviders();
         return (webDriverProviders.size() == 1 && WDP_DEFAULT.equals(provider.label()))
@@ -95,7 +101,7 @@ public abstract class BaseListener {
 
     private void injectSessionId(final ITestResult testResult) {
         ofNullable(DRIVER_CONTAINER.get())
-            .map(t -> t._1)
+            .map(WebDriverContainer::getWebDriver)
             .filter(d -> d instanceof RemoteWebDriver)
             .map(d -> ((RemoteWebDriver) d).getSessionId())
             .ifPresent(id -> testResult.setAttribute("sessionId", id));

--- a/src/test/java/io/github/sskorol/config/RemoteChrome.java
+++ b/src/test/java/io/github/sskorol/config/RemoteChrome.java
@@ -1,0 +1,24 @@
+package io.github.sskorol.config;
+
+import io.github.sskorol.core.Browser;
+import io.github.sskorol.core.CDP;
+
+import static java.lang.String.format;
+
+public class RemoteChrome implements Browser, CDP {
+
+    @Override
+    public Name name() {
+        return Name.Chrome;
+    }
+
+    @Override
+    public boolean isRemote() {
+        return true;
+    }
+
+    @Override
+    public String cdpWebSocketUrl(final String sessionId) {
+        return format("ws://localhost:4444/devtools/%s/page", sessionId);
+    }
+}

--- a/src/test/java/io/github/sskorol/testcases/CoreTests.java
+++ b/src/test/java/io/github/sskorol/testcases/CoreTests.java
@@ -60,7 +60,7 @@ public class CoreTests extends PowerMockTestCase {
 
     @Test
     public void shouldLoadImplementedBrowserServices() {
-        assertThat(browsers).hasSize(4);
+        assertThat(browsers).hasSize(5);
     }
 
     @Test
@@ -68,6 +68,7 @@ public class CoreTests extends PowerMockTestCase {
         assertThat(browsers)
             .extracting(Browser::name)
             .containsExactlyInAnyOrder(
+                Browser.Name.Chrome,
                 Browser.Name.Chrome,
                 Browser.Name.Edge,
                 Browser.Name.Firefox,
@@ -80,7 +81,7 @@ public class CoreTests extends PowerMockTestCase {
         assertThat(browsers)
             .extracting(Browser::name)
             .extracting(Browser.Name::getBrowserName)
-            .containsExactlyInAnyOrder("chrome", "firefox", "edge", "ie");
+            .containsExactlyInAnyOrder("chrome", "chrome", "firefox", "edge", "ie");
     }
 
     @Test
@@ -89,6 +90,7 @@ public class CoreTests extends PowerMockTestCase {
             .extracting(Browser::name)
             .extracting(Browser.Name::getDriverClassName)
             .containsExactlyInAnyOrder(
+                "org.openqa.selenium.chrome.ChromeDriver",
                 "org.openqa.selenium.chrome.ChromeDriver",
                 "org.openqa.selenium.firefox.FirefoxDriver",
                 "org.openqa.selenium.edge.EdgeDriver",

--- a/src/test/java/io/github/sskorol/testcases/FactoryTests1.java
+++ b/src/test/java/io/github/sskorol/testcases/FactoryTests1.java
@@ -13,21 +13,21 @@ public class FactoryTests1 {
 
     @Test
     public void test1() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test2() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test3() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test4() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/FactoryTests2.java
+++ b/src/test/java/io/github/sskorol/testcases/FactoryTests2.java
@@ -8,21 +8,21 @@ public class FactoryTests2 {
 
     @Test
     public void test5() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test6() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test7()  {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test8() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/FactoryTests3.java
+++ b/src/test/java/io/github/sskorol/testcases/FactoryTests3.java
@@ -8,21 +8,21 @@ public class FactoryTests3 {
 
     @Test
     public void test9() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test10() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test11() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test12() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/FactoryTests4.java
+++ b/src/test/java/io/github/sskorol/testcases/FactoryTests4.java
@@ -8,21 +8,21 @@ public class FactoryTests4 {
 
     @Test
     public void test13() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test14() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test15() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test16() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 }

--- a/src/test/java/io/github/sskorol/testcases/FactoryTests5.java
+++ b/src/test/java/io/github/sskorol/testcases/FactoryTests5.java
@@ -8,21 +8,21 @@ public class FactoryTests5 {
 
     @Test
     public void test17() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test18() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test19() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 
     @Test
     public void test20() {
-        getDriverMetaData()._1.get("https://google.com/ncr");
+        getDriverMetaData().getWebDriver().get("https://google.com/ncr");
     }
 }

--- a/src/test/resources/META-INF/services/io.github.sskorol.core.Browser
+++ b/src/test/resources/META-INF/services/io.github.sskorol.core.Browser
@@ -1,4 +1,5 @@
 io.github.sskorol.config.Firefox
 io.github.sskorol.config.Chrome
+io.github.sskorol.config.RemoteChrome
 io.github.sskorol.config.Edge
 io.github.sskorol.config.IE


### PR DESCRIPTION
- Migrated all the deps to Java 17
- Added initial CDP client integration to simplify the setup/cleanup process: basically, a user must implement CDP interface to inject CDP service into WebDriverContainer
- WebDriver and CDP metadata were moved from tuples to a separate container class to improve UX
- Fixed a bunch of tests after migration

Closes #32
Closes #33