### PR TITLE
GITHUB-35: add Java 17 and CDP migration instructions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.4
+version=1.0.0


### PR DESCRIPTION
Added instructions on how to migrate to Java 17 and add CDP support + updated release version.

Closes #35 