### PR TITLE
GH-42: check if includes collection is empty

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.1
+version=1.1.2

--- a/src/main/java/io/github/sskorol/utils/TestNGUtils.java
+++ b/src/main/java/io/github/sskorol/utils/TestNGUtils.java
@@ -15,7 +15,7 @@ import static java.util.Optional.ofNullable;
 import static org.joor.Reflect.onClass;
 import static org.openqa.selenium.remote.CapabilityType.*;
 
-@SuppressWarnings("MissingJavadocType")
+@SuppressWarnings({"MissingJavadocType", "FinalLocalVariable"})
 public final class TestNGUtils {
 
     private TestNGUtils() {
@@ -62,8 +62,8 @@ public final class TestNGUtils {
     }
 
     public static boolean isMethodPresent(final XmlClass xmlClass, final String method) {
-        return StreamEx.of(xmlClass.getIncludedMethods())
-                       .anyMatch(xmlInclude -> xmlInclude.getName().equals(method));
+        var methods = xmlClass.getIncludedMethods();
+        return methods.isEmpty() || StreamEx.of(methods).anyMatch(xmlInclude -> xmlInclude.getName().equals(method));
     }
 
     public static XmlConfig mapConfiguration(final Map<String, String> parameters, final String method) {


### PR DESCRIPTION
It was impossible to read extra class parameters if there are no child include tags present. This update extends the includes check, so that if it's empty, we assume we can continue.

Fixes #42 