### PR TITLE
GH-44: add smarter custom parameters handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ targetCompatibility = JavaVersion.VERSION_17
 dependencies {
     compile(
             'org.testng:testng:7.6.0',
-            'io.github.sskorol:webdriver-supplier:1.1.1'
+            'io.github.sskorol:webdriver-supplier:1.1.3'
     )
 }
     
@@ -132,7 +132,7 @@ Add the following configuration into **pom.xml**:
     <dependency>
         <groupId>io.github.sskorol</groupId>
         <artifactId>webdriver-supplier</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.3</version>
     </dependency>
 </dependencies>
     

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.2
+version=1.1.3

--- a/src/main/java/io/github/sskorol/config/XmlConfig.java
+++ b/src/main/java/io/github/sskorol/config/XmlConfig.java
@@ -3,8 +3,10 @@ package io.github.sskorol.config;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import one.util.streamex.EntryStream;
 import org.openqa.selenium.Platform;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,6 +24,7 @@ public class XmlConfig {
 
     public static final String TEST_NAME = "testName";
     private final Map<String, String> parameters;
+    private final List<String> mandatoryParameters = List.of(BROWSER_NAME, BROWSER_VERSION, PLATFORM_NAME, TEST_NAME);
 
     public String getBrowser() {
         return getValue(BROWSER_NAME)
@@ -62,6 +65,17 @@ public class XmlConfig {
 
     public Optional<String> getValue(final String key) {
         return ofNullable(parameters.get(key));
+    }
+
+    public Map<String, String> getCustomParameters() {
+        return EntryStream.of(parameters)
+            .filterKeys(key -> !mandatoryParameters.contains(key))
+            .toMap();
+    }
+
+    public XmlConfig extendParameters(final Map<String, String> parameters) {
+        this.parameters.putAll(parameters);
+        return this;
     }
 
     @Override

--- a/src/main/java/io/github/sskorol/utils/TestNGUtils.java
+++ b/src/main/java/io/github/sskorol/utils/TestNGUtils.java
@@ -2,11 +2,13 @@ package io.github.sskorol.utils;
 
 import io.github.sskorol.config.XmlConfig;
 import one.util.streamex.StreamEx;
+import org.testng.IInvokedMethod;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlInclude;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
+import java.lang.reflect.Method;
 import java.util.*;
 
 import static io.github.sskorol.config.XmlConfig.TEST_NAME;
@@ -22,23 +24,29 @@ public final class TestNGUtils {
         throw new UnsupportedOperationException("Illegal access to private constructor");
     }
 
-    public static StreamEx<Optional<XmlConfig>> getBrowserConfiguration(final XmlTest xmlTest, final String method) {
-        return StreamEx.of(getMethodBrowserConfiguration(xmlTest, method),
-                getClassBrowserConfiguration(xmlTest, method),
-                getTestGroupBrowserConfiguration(xmlTest, method),
-                getSuiteBrowserConfiguration(xmlTest.getSuite(), method));
+    public static StreamEx<Optional<XmlConfig>> getBrowserConfiguration(
+        final XmlTest xmlTest,
+        final IInvokedMethod method
+    ) {
+        var testMethod = method.getTestMethod().getConstructorOrMethod().getMethod();
+        var methodConfigs = getMethodBrowserConfiguration(xmlTest, testMethod);
+        var classConfigs = getClassBrowserConfiguration(xmlTest, testMethod);
+        var testConfigs = getTestGroupBrowserConfiguration(xmlTest, testMethod);
+        var suiteConfigs = getSuiteBrowserConfiguration(xmlTest.getSuite(), testMethod);
+        return StreamEx.of(methodConfigs, classConfigs, testConfigs, suiteConfigs);
     }
 
-    public static Optional<XmlConfig> getMethodBrowserConfiguration(final XmlTest xmlTest, final String method) {
+    public static Optional<XmlConfig> getMethodBrowserConfiguration(final XmlTest xmlTest, final Method method) {
         return StreamEx.of(xmlTest.getClasses())
+                       .filter(xmlClass -> xmlClass.getName().equalsIgnoreCase(method.getDeclaringClass().getName()))
                        .flatMap(xmlClass -> StreamEx.of(xmlClass.getIncludedMethods()))
-                       .filter(xmlInclude -> xmlInclude.getName().equals(method))
+                       .filter(xmlInclude -> xmlInclude.getName().equals(method.getName()))
                        .map(XmlInclude::getAllParameters)
                        .map(parameters -> mapConfiguration(parameters, method))
                        .findFirst();
     }
 
-    public static Optional<XmlConfig> getClassBrowserConfiguration(final XmlTest xmlTest, final String method) {
+    public static Optional<XmlConfig> getClassBrowserConfiguration(final XmlTest xmlTest, final Method method) {
         return StreamEx.of(xmlTest.getClasses())
                        .filter(xmlClass -> isMethodPresent(xmlClass, method))
                        .map(XmlClass::getAllParameters)
@@ -46,28 +54,34 @@ public final class TestNGUtils {
                        .findFirst();
     }
 
-    public static Optional<XmlConfig> getTestGroupBrowserConfiguration(final XmlTest xmlTest, final String method) {
+    public static Optional<XmlConfig> getTestGroupBrowserConfiguration(final XmlTest xmlTest, final Method method) {
         final Map<String, String> parameters = xmlTest.getAllParameters();
-        parameters.putIfAbsent(TEST_NAME, method);
+        parameters.putIfAbsent(TEST_NAME, method.getName());
         return Optional.of(new XmlConfig(parameters));
     }
 
-    public static Optional<XmlConfig> getSuiteBrowserConfiguration(final XmlSuite xmlSuite, final String method) {
+    public static Optional<XmlConfig> getSuiteBrowserConfiguration(final XmlSuite xmlSuite, final Method method) {
         final Map<String, String> parameters = new HashMap<>();
         ofNullable(xmlSuite.getParameter(BROWSER_NAME)).ifPresent(val -> parameters.put(BROWSER_NAME, val));
         ofNullable(xmlSuite.getParameter(BROWSER_VERSION)).ifPresent(val -> parameters.put(BROWSER_VERSION, val));
         ofNullable(xmlSuite.getParameter(PLATFORM_NAME)).ifPresent(val -> parameters.put(PLATFORM_NAME, val));
-        parameters.putIfAbsent(TEST_NAME, method);
+        parameters.putIfAbsent(TEST_NAME, method.getName());
         return Optional.of(new XmlConfig(unmodifiableMap(parameters)));
     }
 
-    public static boolean isMethodPresent(final XmlClass xmlClass, final String method) {
+    public static boolean isMethodPresent(final XmlClass xmlClass, final Method method) {
+        if (!xmlClass.getName().equalsIgnoreCase(method.getDeclaringClass().getName())) {
+            return false;
+        }
+
         var methods = xmlClass.getIncludedMethods();
-        return methods.isEmpty() || StreamEx.of(methods).anyMatch(xmlInclude -> xmlInclude.getName().equals(method));
+        return methods.isEmpty() || StreamEx.of(methods).anyMatch(
+            xmlInclude -> xmlInclude.getName().equals(method.getName())
+        );
     }
 
-    public static XmlConfig mapConfiguration(final Map<String, String> parameters, final String method) {
-        parameters.putIfAbsent(TEST_NAME, method);
+    public static XmlConfig mapConfiguration(final Map<String, String> parameters, final Method method) {
+        parameters.putIfAbsent(TEST_NAME, method.getName());
         return onClass(XmlConfig.class).create(parameters).get();
     }
 }


### PR DESCRIPTION
It wasn't possible to get custom class-level parameters due to the fact we get only the first config that matches the browser. However, it didn't mean it had custom params. This update contains a new logic of extracting all the custom params beforehand with further merging with the browser config.

Fixes #44